### PR TITLE
Fix bias initialization for LSTM

### DIFF
--- a/rainy/net/init.py
+++ b/rainy/net/init.py
@@ -30,12 +30,16 @@ def zero() -> InitFn:
     return partial(nn.init.constant_, val=0)
 
 
-def forget_bias(val: float) -> InitFn:
-    def __set_bias(t: Tensor, value: float) -> None:
+def lstm_bias(forget: float = 1.0, other: float = 0.0) -> InitFn:
+    """Set forget bias =
+    """
+    def __set_bias(t: Tensor) -> None:
         with torch.no_grad():
             i = len(t) // 4
-            t[i:2 * i].fill_(value)
-    return partial(__set_bias, value=val)
+            t[0:i].fill_(other)
+            t[i:2 * i].fill_(forget)
+            t[i:].fill_(other)
+    return partial(__set_bias)
 
 
 class Initializer:

--- a/rainy/net/recurrent.py
+++ b/rainy/net/recurrent.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import torch
 from torch import nn, Tensor
 from typing import Generic, Iterable, Optional, Sequence, Tuple, TypeVar
-from .init import forget_bias, Initializer
+from .init import lstm_bias, Initializer
 from ..prelude import Self
 from ..utils import Device
 
@@ -85,7 +85,7 @@ class LstmBlock(RnnBlock[LstmState]):
             self,
             input_dim: int,
             output_dim: int,
-            initializer: Initializer = Initializer(bias_init = forget_bias(1.0)),
+            initializer: Initializer = Initializer(bias_init = lstm_bias()),
             **kwargs
     ) -> None:
         super().__init__(input_dim, output_dim)


### PR DESCRIPTION
In the code written in #8, we set 1.0 for bias, but do nothing for other parts.
Other parts([ingate, cellgate, outgate](https://github.com/pytorch/pytorch/issues/750)) should be filled with 0.